### PR TITLE
Fixing the type hints and linting

### DIFF
--- a/src/opentelemetry/instrumentation/digma/trace_decorator.py
+++ b/src/opentelemetry/instrumentation/digma/trace_decorator.py
@@ -1,8 +1,9 @@
 import asyncio
 import inspect
 from functools import wraps
-from typing import Callable, Optional
+from typing import Callable
 from typing import Dict
+from typing import Optional
 
 from opentelemetry import trace
 from opentelemetry.semconv.trace import SpanAttributes
@@ -120,9 +121,7 @@ def instrument(
         @wraps(func_or_class)
         def wrap_with_span_sync(*args, **kwargs):
             name = span_name or TracingDecoratorOptions.naming_scheme(func_or_class)
-            with tracer.start_as_current_span(
-                name, record_exception=record_exception
-            ) as span:
+            with tracer.start_as_current_span(name, record_exception=record_exception) as span:
                 _set_semantic_attributes(span, func_or_class)
                 _set_attributes(span, TracingDecoratorOptions.default_attributes)
                 _set_attributes(span, attributes)
@@ -131,9 +130,7 @@ def instrument(
         @wraps(func_or_class)
         async def wrap_with_span_async(*args, **kwargs):
             name = span_name or TracingDecoratorOptions.naming_scheme(func_or_class)
-            with tracer.start_as_current_span(
-                name, record_exception=record_exception
-            ) as span:
+            with tracer.start_as_current_span(name, record_exception=record_exception) as span:
                 _set_semantic_attributes(span, func_or_class)
                 _set_attributes(span, TracingDecoratorOptions.default_attributes)
                 _set_attributes(span, attributes)
@@ -142,11 +139,7 @@ def instrument(
         if ignore:
             return func_or_class
 
-        wrapper = (
-            wrap_with_span_async
-            if asyncio.iscoroutinefunction(func_or_class)
-            else wrap_with_span_sync
-        )
+        wrapper = wrap_with_span_async if asyncio.iscoroutinefunction(func_or_class) else wrap_with_span_sync
         wrapper.__signature__ = inspect.signature(func_or_class)
 
         return wrapper

--- a/src/opentelemetry/instrumentation/digma/trace_decorator.py
+++ b/src/opentelemetry/instrumentation/digma/trace_decorator.py
@@ -8,9 +8,6 @@ from opentelemetry import trace
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Tracer
 
-import logging
-
-logger = logging.getLogger()
 
 class TracingDecoratorOptions:
     class NamingSchemes:


### PR DESCRIPTION
Hello,

First of all, thank you for this code snippet —it is outstanding and among the most practical I have seen.

I am submitting this pull request with only a few cosmetic adjustments:

Added explicit Optional annotations to certain parameters, because mypy does not allow the implicit form.

Ran the code through a linter; if it still falls outside the preferred style, I can re‑format it.

Inserted a None check in set_default_attributes to prevent mypy errors.

Kind regards,
Gabriel de Carvalho